### PR TITLE
Add some minor changes to the “no bold” theme variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v.0.3.2
+
+- Change casing to “No Bold” and add a space before the parenthesis in the theme name
+
 ## v.0.3.1
 
 - Add `no bold` theme variant

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-zenburn-plus-theme",
   "displayName": "Zenburn+ Dark Theme",
   "description": "Theme based on zenburn-emacs colour theme ported to VS Code",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "publisher": "igolskyi",
   "repository": {
     "type": "git",
@@ -23,7 +23,7 @@
         "path": "./themes/zenburn.json"
       },
       {
-        "label": "Zenburn+ Dark(no bold)",
+        "label": "Zenburn+ Dark (No Bold)",
         "uiTheme": "vs-dark",
         "path": "./themes/zenburn-no-bold.json"
       }


### PR DESCRIPTION
This pull request changes the casing to “No Bold” and add a space before the parenthesis in the theme name.